### PR TITLE
update description of CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ One-click WordPress plugin that converts all posts, pages, taxonomies, metadata,
 
 If you're having trouble with your web server timing out before the export is complete, or if you just like terminal better, you may enjoy the command-line tool.
 
-It works just like the plugin, but produces the zipfile on STDOUT:
+It works just like the plugin, but produces the zipfile at `/tmp/wp-hugo.zip`:
 
-    php hugo-export-cli.php > hugo-export.zip
+    php hugo-export-cli.php
 
 Alternatively, if you have [WP-CLI](http://wp-cli.org) installed, you can run:
 


### PR DESCRIPTION
As of 19baf765bd27d76cc87c7e7b59325bfec0d60cd0 (at least) running `php hugo-export-cli.php` will generate `/tmp/wp-hugo.zip`; STDOUT is just a message stating:
```
This is your file!
/tmp/wp-hugo.zip
```
This should help clarify for people who are having problems with an "empty zip file" ([example](http://justindunham.net/migrating-from-wordpress-to-hugo/)).