### PR TITLE
Changed script to generate `config.yaml` and `post`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ One-click WordPress plugin that converts all posts, pages, taxonomies, metadata,
 * Export what your users see, not what the database stores (runs post content through `the_content` filter prior to export, allowing third-party plugins to modify the output)
 * Converts all `post_content` to Markdown Extra (using Markdownify)
 * Converts all `post_meta` and fields within the `wp_posts` table to YAML front matter for parsing by Hugo
-* Generates a `_config.yml` with all settings in the `wp_options` table
-* Outputs a single zip file with `_config.yml`, pages, and `_posts` folder containing `.md` files for each post in the proper Hugo naming convention
+* Generates a `config.yaml` with all settings in the `wp_options` table
+* Outputs a single zip file with `config.yaml`, pages, and `posts` folder containing `.md` files for each post in the proper Hugo naming convention
 * No settings. Just a single click.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ One-click WordPress plugin that converts all posts, pages, taxonomies, metadata,
 * Converts all `post_content` to Markdown Extra (using Markdownify)
 * Converts all `post_meta` and fields within the `wp_posts` table to YAML front matter for parsing by Hugo
 * Generates a `config.yaml` with all settings in the `wp_options` table
-* Outputs a single zip file with `config.yaml`, pages, and `posts` folder containing `.md` files for each post in the proper Hugo naming convention
+* Outputs a single zip file with `config.yaml`, pages, and `post` folder containing `.md` files for each post in the proper Hugo naming convention
 * No settings. Just a single click.
 
 ## Usage

--- a/hugo-export.php
+++ b/hugo-export.php
@@ -28,7 +28,7 @@ class Hugo_Export
 {
     protected $_tempDir = null;
     private $zip_folder = 'hugo-export/'; //folder zip file extracts to
-    private $post_folder = 'posts/'; //folder to place posts within
+    private $post_folder = 'post/'; //folder to place posts within
 
     public $rename_options = array('site', 'blog'); //strings to strip from option keys on export
 

--- a/hugo-export.php
+++ b/hugo-export.php
@@ -28,11 +28,11 @@ class Hugo_Export
 {
     protected $_tempDir = null;
     private $zip_folder = 'hugo-export/'; //folder zip file extracts to
-    private $post_folder = '_posts/'; //folder to place posts within
+    private $post_folder = 'posts/'; //folder to place posts within
 
     public $rename_options = array('site', 'blog'); //strings to strip from option keys on export
 
-    public $options = array( //array of wp_options value to convert to _config.yml
+    public $options = array( //array of wp_options value to convert to config.yaml
         'name',
         'description',
         'url'
@@ -287,7 +287,7 @@ class Hugo_Export
     }
 
     /**
-     * Convert options table to _config.yml file
+     * Convert options table to config.yaml file
      */
     function convert_options()
     {
@@ -324,7 +324,7 @@ class Hugo_Export
         //strip starting "---"
         $output = substr($output, 4);
 
-        $wp_filesystem->put_contents($this->dir . '_config.yml', $output);
+        $wp_filesystem->put_contents($this->dir . 'config.yaml', $output);
     }
 
     /**


### PR DESCRIPTION
Changed script to generate `config.yaml` and `post` instead of `_config.yml` and `_post`, in accordance with Hugo conventions.

Here are the Hugo doc references:

https://gohugo.io/overview/configuration/ (config.yaml)
https://gohugo.io/content/organization/ (post)


