### PR TITLE
Fix page type key name.

### DIFF
--- a/hugo-export.php
+++ b/hugo-export.php
@@ -115,7 +115,7 @@ class Hugo_Export
         $output = array(
             'title'  => html_entity_decode(get_the_title($post)),
             'author' => get_userdata($post->post_author)->display_name,
-            'layout' => get_post_type($post),
+            'type' => get_post_type($post),
             'date'   => $this->_getPostDateAsIso($post),
         );
         if (false === empty($post->post_excerpt)) {


### PR DESCRIPTION
Change the front-matter key for the page type to `type` instead of `layout`.