### PR TITLE
parse iframe as link

### DIFF
--- a/hugo-export.php
+++ b/hugo-export.php
@@ -220,7 +220,6 @@ class Hugo_Export
      */
     function convert_content($post)
     {
-
         $content   = apply_filters('the_content', $post->post_content);
         $converter = new Markdownify\ConverterExtra;
         $markdown  = $converter->parseString($content);

--- a/includes/markdownify/Converter.php
+++ b/includes/markdownify/Converter.php
@@ -109,7 +109,7 @@ class Converter
             'href' => 'required',
             'title' => 'optional',
         ),
-		'iframe' => array(
+        'iframe' => array(
             'src' => 'required'
         ),
         'strong' => array(),
@@ -833,16 +833,16 @@ class Converter
      */
     protected function handleTag_iframe()
     {
-		if ($this->parser->isStartTag) {
+        if ($this->parser->isStartTag) {
             $this->buffer();
             $this->handleTag_iframe_parser();
             $this->stack();
         } else {
-			$tag = $this->unstack();
-			$buffer = $this->unbuffer();
-			$this->handleTag_iframe_converter($tag, $buffer);
-			$this->out($this->handleTag_iframe_converter($tag, $buffer), true);
-		}
+        	$tag = $this->unstack();
+        	$buffer = $this->unbuffer();
+        	$this->handleTag_iframe_converter($tag, $buffer);
+        	$this->out($this->handleTag_iframe_converter($tag, $buffer), true);
+        }
     }
 	
 	/**

--- a/includes/markdownify/Converter.php
+++ b/includes/markdownify/Converter.php
@@ -109,6 +109,9 @@ class Converter
             'href' => 'required',
             'title' => 'optional',
         ),
+		'iframe' => array(
+            'src' => 'required'
+        ),
         'strong' => array(),
         'b' => array(),
         'em' => array(),
@@ -150,7 +153,6 @@ class Converter
         'area',
         'object',
         'param',
-        'iframe',
     );
 
     /**
@@ -821,6 +823,50 @@ class Converter
         }
 
         return '[' . $buffer . '][' . $tag['linkID'] . ']';
+    }
+	
+	/**
+     * handle <iframe> tags
+     *
+     * @param void
+     * @return void
+     */
+    protected function handleTag_iframe()
+    {
+		if ($this->parser->isStartTag) {
+            $this->buffer();
+            $this->handleTag_iframe_parser();
+            $this->stack();
+        } else {
+			$tag = $this->unstack();
+			$buffer = $this->unbuffer();
+			$this->handleTag_iframe_converter($tag, $buffer);
+			$this->out($this->handleTag_iframe_converter($tag, $buffer), true);
+		}
+    }
+	
+	/**
+     * handle <iframe> tags parsing
+     *
+     * @param void
+     * @return void
+     */
+    protected function handleTag_iframe_parser()
+    {
+        $this->parser->tagAttributes['src'] = $this->decode(trim($this->parser->tagAttributes['src']));
+    }
+
+    /**
+     * handle <iframe> tags conversion
+     * The Hugo Generator should handle video links, by transforming them into iframes again
+	 *
+     * @param array $tag
+     * @param string $buffer
+     * @return string The markdownified link from the iframe
+     */
+    protected function handleTag_iframe_converter($tag, $buffer)
+    { 
+        return '[' . $tag['src'] . ']';
     }
 
     /**

--- a/includes/markdownify/ConverterExtra.php
+++ b/includes/markdownify/ConverterExtra.php
@@ -68,6 +68,12 @@ class ConverterExtra extends Converter
         // link class
         $this->isMarkdownable['a']['id'] = 'optional';
         $this->isMarkdownable['a']['class'] = 'optional';
+		// iframe optionals
+		$this->isMarkdownable['iframe']['width'] = 'optional';
+        $this->isMarkdownable['iframe']['height'] = 'optional';
+		$this->isMarkdownable['iframe']['allow'] = 'optional';
+		$this->isMarkdownable['iframe']['allowfullscreen'] = 'optional';
+		$this->isMarkdownable['iframe']['frameborder'] = 'optional';
         // footnotes
         $this->isMarkdownable['fnref'] = array(
             'target' => 'required',
@@ -150,6 +156,36 @@ class ConverterExtra extends Converter
     protected function handleTag_a_converter($tag, $buffer)
     {
         $output = parent::handleTag_a_converter($tag, $buffer);
+        if (!empty($tag['cssSelector'])) {
+            // [This link][id]{#id.class}
+            $output .= '{' . $tag['cssSelector'] . '}';
+        }
+
+        return $output;
+    }
+	
+	/**
+     * handle <iframe> tags parsing
+     *
+     * @param void
+     * @return void
+     */
+    protected function handleTag_iframe_parser()
+    {
+        parent::handleTag_iframe_parser();
+        $this->parser->tagAttributes['cssSelector'] = $this->getCurrentCssSelector();
+    }
+
+    /**
+     * handle <iframe> tags conversion
+     *
+     * @param array $tag
+     * @param string $buffer
+     * @return string The markdownified link
+     */
+    protected function handleTag_iframe_converter($tag, $buffer)
+    {
+        $output = parent::handleTag_iframe_converter($tag, $buffer);
         if (!empty($tag['cssSelector'])) {
             // [This link][id]{#id.class}
             $output .= '{' . $tag['cssSelector'] . '}';

--- a/includes/markdownify/ConverterExtra.php
+++ b/includes/markdownify/ConverterExtra.php
@@ -68,12 +68,12 @@ class ConverterExtra extends Converter
         // link class
         $this->isMarkdownable['a']['id'] = 'optional';
         $this->isMarkdownable['a']['class'] = 'optional';
-		// iframe optionals
-		$this->isMarkdownable['iframe']['width'] = 'optional';
+        // iframe optionals
+        $this->isMarkdownable['iframe']['width'] = 'optional';
         $this->isMarkdownable['iframe']['height'] = 'optional';
-		$this->isMarkdownable['iframe']['allow'] = 'optional';
-		$this->isMarkdownable['iframe']['allowfullscreen'] = 'optional';
-		$this->isMarkdownable['iframe']['frameborder'] = 'optional';
+        $this->isMarkdownable['iframe']['allow'] = 'optional';
+        $this->isMarkdownable['iframe']['allowfullscreen'] = 'optional';
+        $this->isMarkdownable['iframe']['frameborder'] = 'optional';
         // footnotes
         $this->isMarkdownable['fnref'] = array(
             'target' => 'required',


### PR DESCRIPTION
Videos are embedded as iframe in Wordpress posts. Hugo should handle video links accordingly (or a plugin). At least by inserting this links into the markdown file they don't get lost during the export.