### PR TITLE
Surpressed displaying waning and updated markdownify

### DIFF
--- a/hugo-export.php
+++ b/hugo-export.php
@@ -568,6 +568,8 @@ class Hugo_Export
     }
 }
 
+ini_set('display_errors', 0);
+
 $je = new Hugo_Export();
 
 if (defined('WP_CLI') && WP_CLI) {

--- a/includes/markdownify/Converter.php
+++ b/includes/markdownify/Converter.php
@@ -1,7 +1,5 @@
 <?php
 
-/* This file is part of the Markdownify project, which is under LGPL license */
-
 namespace Markdownify;
 
 /**
@@ -34,7 +32,7 @@ class Converter
      *
      * @var array<string>
      */
-    protected $notConverted = array();
+    protected $notConverted = [];
 
     /**
      * skip conversion to markdown
@@ -82,70 +80,67 @@ class Converter
      *
      * @var array<string>
      */
-    protected $buffer = array();
+    protected $buffer = [];
 
     /**
      * stores current buffers
      *
      * @var array<string>
      */
-    protected $footnotes = array();
+    protected $footnotes = [];
 
     /**
      * tags with elements which can be handled by markdown
      *
      * @var array<string>
      */
-    protected $isMarkdownable = array(
-        'p' => array(),
-        'ul' => array(),
-        'ol' => array(),
-        'li' => array(),
-        'br' => array(),
-        'blockquote' => array(),
-        'code' => array(),
-        'pre' => array(),
-        'a' => array(
+    protected $isMarkdownable = [
+        'p' => [],
+        'ul' => [],
+        'ol' => [],
+        'li' => [],
+        'br' => [],
+        'blockquote' => [],
+        'code' => [],
+        'pre' => [],
+        'a' => [
             'href' => 'required',
             'title' => 'optional',
-        ),
-        'iframe' => array(
-            'src' => 'required'
-        ),
-        'strong' => array(),
-        'b' => array(),
-        'em' => array(),
-        'i' => array(),
-        'img' => array(
+        ],
+        'strong' => [],
+        'b' => [],
+        'em' => [],
+        'i' => [],
+        'img' => [
             'src' => 'required',
             'alt' => 'optional',
             'title' => 'optional',
-        ),
-        'h1' => array(),
-        'h2' => array(),
-        'h3' => array(),
-        'h4' => array(),
-        'h5' => array(),
-        'h6' => array(),
-        'hr' => array(),
-    );
+        ],
+        'h1' => [],
+        'h2' => [],
+        'h3' => [],
+        'h4' => [],
+        'h5' => [],
+        'h6' => [],
+        'hr' => [],
+    ];
 
     /**
      * html tags to be ignored (contents will be parsed)
      *
      * @var array<string>
      */
-    protected $ignore = array(
+    protected $ignore = [
         'html',
         'body',
-    );
+    ];
 
     /**
      * html tags to be dropped (contents will not be parsed!)
      *
      * @var array<string>
      */
-    protected $drop = array(
+    protected $drop = [
         'script',
         'head',
         'style',
@@ -153,16 +148,17 @@ class Converter
         'area',
         'object',
         'param',
-    );
+        'iframe',
+    ];
 
     /**
      * html block tags that allow inline & block children
      *
      * @var array<string>
      */
-    protected $allowMixedChildren = array(
+    protected $allowMixedChildren = [
         'li'
-    );
+    ];
 
     /**
      * Markdown indents which could be wrapped
@@ -170,13 +166,13 @@ class Converter
      *
      * @var array<string>
      */
-    protected $wrappableIndents = array(
+    protected $wrappableIndents = [
         '\*   ', // ul
         '\d.  ', // ol
         '\d\d. ', // ol
         '> ', // blockquote
         '', // p
-    );
+    ];
 
     /**
      * list of chars which have to be escaped in normal text
@@ -186,7 +182,7 @@ class Converter
      *
      * TODO: what's with block chars / sequences at the beginning of a block?
      */
-    protected $escapeInText = array(
+    protected $escapeInText = [
         '\*\*([^*]+)\*\*' => '\*\*$1\*\*', // strong
         '\*([^*]+)\*' => '\*$1\*', // em
         '__(?! |_)(.+)(?!<_| )__' => '\_\_$1\_\_', // strong
@@ -196,7 +192,7 @@ class Converter
         '\[(.+)\](\s*\()' => '\[$1\]$2', // links: [text] (url) => [text\] (url)
         '\[(.+)\](\s*)\[(.*)\]' => '\[$1\]$2\[$3\]', // links: [text][id] => [text\][id\]
         '^#(#{0,5}) ' => '\#$1 ', // header
-    );
+    ];
 
     /**
      * wether last processed node was a block tag or not
@@ -222,7 +218,7 @@ class Converter
      *
      * @var array<array>
      */
-    protected $stack = array();
+    protected $stack = [];
 
     /**
      * current indentation
@@ -256,16 +252,16 @@ class Converter
         $this->parser->noTagsInCode = true;
 
         // we don't have to do this every time
-        $search = array();
-        $replace = array();
+        $search = [];
+        $replace = [];
         foreach ($this->escapeInText as $s => $r) {
             array_push($search, '@(?<!\\\)' . $s . '@U');
             array_push($replace, $r);
         }
-        $this->escapeInText = array(
+        $this->escapeInText = [
             'search' => $search,
             'replace' => $replace
-        );
+        ];
     }
 
     /**
@@ -314,9 +310,10 @@ class Converter
      * @return void
      */
     protected function parse()
-    { 
+    {
         $this->output = '';
-        // drop tags
+
+        // Drop tags
         $this->parser->html = preg_replace('#<(' . implode('|', $this->drop) . ')[^>]*>.*</\\1>#sU', '', $this->parser->html);
         while ($this->parser->nextNode()) {
             switch ($this->parser->nodeType) {
@@ -348,7 +345,7 @@ class Converter
                     if ($this->skipConversion) {
                         $this->isMarkdownable(); // update notConverted
                         $this->handleTagToText();
-                        continue;
+                        break;
                     }
 
                     // block elements
@@ -373,7 +370,6 @@ class Converter
                             }
                         }
                         $func = 'handleTag_' . $this->parser->tagName;
-
                         $this->$func();
                         if ($this->linkPosition == self::LINK_AFTER_PARAGRAPH && $this->parser->isBlockElement && !$this->parser->isStartTag && empty($this->parser->openTags)) {
                             $this->flushFootnotes();
@@ -402,7 +398,7 @@ class Converter
         $this->output = rtrim(str_replace('&amp;', '&', str_replace('&lt;', '<', str_replace('&gt;', '>', $this->output))));
         // end parsing, flush stacked tags
         $this->flushFootnotes();
-        $this->stack = array();
+        $this->stack = [];
     }
 
     /**
@@ -514,7 +510,7 @@ class Converter
                 $this->setLineBreaks(2);
             }
         } else {
-            // dont convert to markdown inside this tag
+            // don't convert to markdown inside this tag
             /** TODO: markdown extra **/
             if (!$this->parser->isEmptyTag) {
                 if ($this->parser->isStartTag) {
@@ -531,7 +527,7 @@ class Converter
             if ($this->parser->isBlockElement) {
                 if ($this->parser->isStartTag) {
                     // looks like ins or del are block elements now
-                    if (in_array($this->parent(), array('ins', 'del'))) {
+                    if (in_array($this->parent(), ['ins', 'del'])) {
                         $this->out("\n", true);
                         $this->indent('  ');
                     }
@@ -564,7 +560,7 @@ class Converter
                         $this->indent = $indent;
                     }
 
-                    if (in_array($this->parent(), array('ins', 'del'))) {
+                    if (in_array($this->parent(), ['ins', 'del'])) {
                         // ins or del was block element
                         $this->out("\n");
                         $this->indent('  ');
@@ -578,7 +574,7 @@ class Converter
             } else {
                 $this->out($this->parser->node);
             }
-            if (in_array($this->parser->tagName, array('code', 'pre'))) {
+            if (in_array($this->parser->tagName, ['code', 'pre'])) {
                 if ($this->parser->isStartTag) {
                     $this->buffer();
                 } else {
@@ -608,7 +604,7 @@ class Converter
                 $this->parser->node = preg_replace($this->escapeInText['search'], $this->escapeInText['replace'], $this->parser->node);
             }
         } else {
-            $this->parser->node = str_replace(array('&quot;', '&apos'), array('"', '\''), $this->parser->node);
+            $this->parser->node = str_replace(['&quot;', '&apos'], ['"', '\''], $this->parser->node);
         }
         $this->out($this->parser->node);
         $this->lastClosedTag = '';
@@ -825,96 +821,6 @@ class Converter
 
         return '[' . $buffer . '][' . $tag['linkID'] . ']';
     }
-	
-	/**
-     * handle <iframe> tags
-     *
-     * @param void
-     * @return void
-     */
-    protected function handleTag_iframe()
-    {
-        if ($this->parser->isStartTag) {
-            $this->buffer();
-            $this->handleTag_iframe_parser();
-            $this->stack();
-        } else {
-        	$tag = $this->unstack();
-        	$buffer = $this->unbuffer();
-        	$this->handleTag_iframe_converter($tag, $buffer);
-        	$this->out($this->handleTag_iframe_converter($tag, $buffer), true);
-        }
-    }
-	
-	/**
-     * handle <iframe> tags parsing them if possible as video template for hugo
-     *
-     * @param void
-     * @return void
-     */
-    protected function handleTag_iframe_parser()
-    {
-
-        $iframeLink = $this->decode(trim($this->parser->tagAttributes['src']));
-        $sourceType = null;
-        
-        if (strpos($iframeLink, 'youtube') !== false) {
-        	$sourceType = "youtube";
-        }
-        
-        if (strpos($iframeLink, 'vimeo') !== false) {
-        	$sourceType = "vimeo";
-        }
-
-        $replaceArray = array("https://www.youtube.com/embed/","http://www.youtube.com/embed/","?feature=oembed");
-        $transformedLink = str_replace($replaceArray,"", $iframeLink);
-		
-		if (strpos($transformedLink, 'vimeo.com') !== false) {
-			$transformedLink = trim(substr($transformedLink, strrpos($transformedLink, '/') + 1));
-		}
-        
-        if (strpos($transformedLink, 'http') === false) {
-        	$transformedLink = "{{< $sourceType $transformedLink >}}";
-        }
-		
-        $this->parser->tagAttributes['src'] = $this->decode(trim($this->parser->tagAttributes['src']));
-    }
-
-    /**
-     * handle <iframe> tags conversion
-     * The Hugo Generator should handle video links, by transforming them into iframes again
-	 *
-     * @param array $tag
-     * @param string $buffer
-     * @return string The markdownified link from the iframe
-     */
-    protected function handleTag_iframe_converter($tag, $buffer)
-    { 
-		$sourceType = null;
-        
-		$link = $tag['src'];
-		
-        if (strpos($link, 'youtube') !== false) {
-        	$sourceType = "youtube";
-        }
-        
-        if (strpos($link, 'vimeo') !== false) {
-        	$sourceType = "vimeo";
-        }
-
-        $replaceArray = array("https://www.youtube.com/embed/","http://www.youtube.com/embed/","?feature=oembed");
-        $transformedLink = str_replace($replaceArray,"", $link);
-		
-		if (strpos($transformedLink, 'vimeo.com') !== false) {
-			$transformedLink = trim(substr($transformedLink, strrpos($transformedLink, '/') + 1));
-		}
-
-        if (strpos($transformedLink, 'http') === false) {
-        	return $transformedLink = "{{< $sourceType $transformedLink >}}";
-        } else {
-			return "[$transformedLink]";
-		}
-    }
 
     /**
      * handle <img /> tags
@@ -977,11 +883,11 @@ class Converter
         }
         if (!$link_id) {
             $link_id = count($this->footnotes) + 1;
-            $tag = array(
+            $tag = [
                 'href' => $this->parser->tagAttributes['src'],
                 'linkID' => $link_id,
                 'title' => $this->parser->tagAttributes['title']
-            );
+            ];
             array_push($this->footnotes, $tag);
         }
         $out .= '[' . $link_id . ']';
@@ -1080,14 +986,14 @@ class Converter
         } else {
             $this->unstack();
             if ($this->parent() != 'li' || preg_match('#^\s*(</li\s*>\s*<li\s*>\s*)?<(p|blockquote)\s*>#sU', $this->parser->html)) {
-                // dont make Markdown add unneeded paragraphs
+                // don't make Markdown add unneeded paragraphs
                 $this->setLineBreaks(2);
             }
         }
     }
 
     /**
-     * handle <ul> tags
+     * handle <ol> tags
      *
      * @param void
      * @return void
@@ -1161,7 +1067,7 @@ class Converter
     protected function stack()
     {
         if (!isset($this->stack[$this->parser->tagName])) {
-            $this->stack[$this->parser->tagName] = array();
+            $this->stack[$this->parser->tagName] = [];
         }
         array_push($this->stack[$this->parser->tagName], $this->parser->tagAttributes);
     }
@@ -1312,54 +1218,9 @@ class Converter
      * @author derernst@gmx.ch <http://www.php.net/manual/en/function.html-entity-decode.php#68536>
      * @author Milian Wolff <http://milianw.de>
      */
-    protected function decode($text, $quote_style = ENT_QUOTES)
+    protected function decode($text)
     {
-        return htmlspecialchars_decode($text, $quote_style);
-    }
-
-    /**
-     * callback for decode() which converts a hexadecimal entity to UTF-8
-     *
-     * @param array $matches
-     * @return string UTF-8 encoded
-     */
-    protected function _decode_hex($matches)
-    {
-        return $this->unichr(hexdec($matches[1]));
-    }
-
-    /**
-     * callback for decode() which converts a numerical entity to UTF-8
-     *
-     * @param array $matches
-     * @return string UTF-8 encoded
-     */
-    protected function _decode_numeric($matches)
-    {
-        return $this->unichr($matches[1]);
-    }
-
-    /**
-     * UTF-8 chr() which supports numeric entities
-     *
-     * @author grey - greywyvern - com <http://www.php.net/manual/en/function.chr.php#55978>
-     * @param array $matches
-     * @return string UTF-8 encoded
-     */
-    protected function unichr($dec)
-    {
-        if ($dec < 128) {
-            $utf = chr($dec);
-        } elseif ($dec < 2048) {
-            $utf = chr(192 + (($dec - ($dec % 64)) / 64));
-            $utf .= chr(128 + ($dec % 64));
-        } else {
-            $utf = chr(224 + (($dec - ($dec % 4096)) / 4096));
-            $utf .= chr(128 + ((($dec % 4096) - ($dec % 64)) / 64));
-            $utf .= chr(128 + ($dec % 64));
-        }
-
-        return $utf;
+        return htmlspecialchars_decode($text, ENT_QUOTES);
     }
 
     /**
@@ -1399,7 +1260,7 @@ class Converter
         while (preg_match($regexp, $str, $matches)) {
             $string = $matches[0];
             $str = ltrim(substr($str, strlen($string)));
-            if (!$cut && isset($str[0]) && in_array($str[0], array('.', '!', ';', ':', '?', ','))) {
+            if (!$cut && isset($str[0]) && in_array($str[0], ['.', '!', ';', ':', '?', ','])) {
                 $string .= $str[0];
                 $str = ltrim(substr($str, 1));
             }
@@ -1453,7 +1314,7 @@ class Converter
      */
     protected function fixInlineElementSpacing()
     {
-        if ($this->parser->isStartTag) {
+        if ($this->parser->isStartTag && !$this->parser->isEmptyTag) {
             // move spaces after the start element to before the element
             if (preg_match('~^(\s+)~', $this->parser->html, $matches)) {
                 $this->out($matches[1]);
@@ -1480,14 +1341,14 @@ class Converter
      */
     protected function resetState()
     {
-        $this->notConverted = array();
+        $this->notConverted = [];
         $this->skipConversion = false;
-        $this->buffer = array();
+        $this->buffer = [];
         $this->indent = '';
-        $this->stack = array();
+        $this->stack = [];
         $this->lineBreaks = 0;
         $this->lastClosedTag = '';
         $this->lastWasBlockTag = false;
-        $this->footnotes = array();
+        $this->footnotes = [];
     }
 }

--- a/includes/markdownify/ConverterExtra.php
+++ b/includes/markdownify/ConverterExtra.php
@@ -1,7 +1,5 @@
 <?php
 
-/* This file is part of the Markdownify project, which is under LGPL license */
-
 namespace Markdownify;
 
 class ConverterExtra extends Converter
@@ -12,7 +10,7 @@ class ConverterExtra extends Converter
      *
      * @var array
      */
-    protected $table = array();
+    protected $table = [];
 
     /**
      * current col
@@ -27,16 +25,6 @@ class ConverterExtra extends Converter
      * @var int
      */
     protected $row = 0;
-
-    /**
-     * @var string
-     */
-    protected $tableLookaheadBody;
-
-    /**
-     * @var string
-     */
-    protected $tableLookaheadHeader;
 
     /**
      * constructor, see Markdownify::Markdownify() for more information
@@ -60,45 +48,39 @@ class ConverterExtra extends Converter
         $this->isMarkdownable['h6']['id'] = 'optional';
         $this->isMarkdownable['h6']['class'] = 'optional';
         // tables
-        $this->isMarkdownable['table'] = array();
-        $this->isMarkdownable['th'] = array(
+        $this->isMarkdownable['table'] = [];
+        $this->isMarkdownable['th'] = [
             'align' => 'optional',
-        );
-        $this->isMarkdownable['td'] = array(
+        ];
+        $this->isMarkdownable['td'] = [
             'align' => 'optional',
-        );
-        $this->isMarkdownable['tr'] = array();
+        ];
+        $this->isMarkdownable['tr'] = [];
         array_push($this->ignore, 'thead');
         array_push($this->ignore, 'tbody');
         array_push($this->ignore, 'tfoot');
         // definition lists
-        $this->isMarkdownable['dl'] = array();
-        $this->isMarkdownable['dd'] = array();
-        $this->isMarkdownable['dt'] = array();
+        $this->isMarkdownable['dl'] = [];
+        $this->isMarkdownable['dd'] = [];
+        $this->isMarkdownable['dt'] = [];
         // link class
         $this->isMarkdownable['a']['id'] = 'optional';
         $this->isMarkdownable['a']['class'] = 'optional';
-        // iframe optionals
-        $this->isMarkdownable['iframe']['width'] = 'optional';
-        $this->isMarkdownable['iframe']['height'] = 'optional';
-        $this->isMarkdownable['iframe']['allow'] = 'optional';
-        $this->isMarkdownable['iframe']['allowfullscreen'] = 'optional';
-        $this->isMarkdownable['iframe']['frameborder'] = 'optional';
         // footnotes
-        $this->isMarkdownable['fnref'] = array(
+        $this->isMarkdownable['fnref'] = [
             'target' => 'required',
-        );
-        $this->isMarkdownable['footnotes'] = array();
-        $this->isMarkdownable['fn'] = array(
+        ];
+        $this->isMarkdownable['footnotes'] = [];
+        $this->isMarkdownable['fn'] = [
             'name' => 'required',
-        );
+        ];
         $this->parser->blockElements['fnref'] = false;
         $this->parser->blockElements['fn'] = true;
         $this->parser->blockElements['footnotes'] = true;
         // abbr
-        $this->isMarkdownable['abbr'] = array(
+        $this->isMarkdownable['abbr'] = [
             'title' => 'required',
-        );
+        ];
         // build RegEx lookahead to decide wether table can pe parsed or not
         $inlineTags = array_keys($this->parser->blockElements, false);
         $colContents = '(?:[^<]|<(?:' . implode('|', $inlineTags) . '|[^a-z]))*';
@@ -173,36 +155,6 @@ class ConverterExtra extends Converter
 
         return $output;
     }
-	
-	/**
-     * handle <iframe> tags parsing
-     *
-     * @param void
-     * @return void
-     */
-    protected function handleTag_iframe_parser()
-    {
-        parent::handleTag_iframe_parser();
-        $this->parser->tagAttributes['cssSelector'] = $this->getCurrentCssSelector();
-    }
-
-    /**
-     * handle <iframe> tags conversion
-     *
-     * @param array $tag
-     * @param string $buffer
-     * @return string The markdownified link
-     */
-    protected function handleTag_iframe_converter($tag, $buffer)
-    {
-        $output = parent::handleTag_iframe_converter($tag, $buffer);
-        if (!empty($tag['cssSelector'])) {
-            // [This link][id]{#id.class}
-            $output .= '{' . $tag['cssSelector'] . '}';
-        }
-
-        return $output;
-    }
 
     /**
      * handle <abbr> tags
@@ -241,7 +193,7 @@ class ConverterExtra extends Converter
      */
     protected function flushStacked_abbr()
     {
-        $out = array();
+        $out = [];
         foreach ($this->stack['abbr'] as $k => $tag) {
             if (!isset($tag['unstacked'])) {
                 array_push($out, ' *[' . $tag['text'] . ']: ' . $tag['title']);
@@ -271,7 +223,7 @@ class ConverterExtra extends Converter
                     preg_match_all('#<th(?:\s+align=("|\')(left|right|center)\1)?\s*>#si', $matches[0], $cols);
                     $regEx = '';
                     $i = 1;
-                    $aligns = array();
+                    $aligns = [];
                     foreach ($cols[2] as $align) {
                         $align = strtolower($align);
                         array_push($aligns, $align);
@@ -290,11 +242,11 @@ class ConverterExtra extends Converter
                     $regEx = sprintf($this->tableLookaheadBody, $regEx);
                     if (preg_match($regEx, $this->parser->html, $matches, null, strlen($matches[0]))) {
                         // this is a markdownable table tag!
-                        $this->table = array(
-                            'rows' => array(),
-                            'col_widths' => array(),
+                        $this->table = [
+                            'rows' => [],
+                            'col_widths' => [],
                             'aligns' => $aligns,
-                        );
+                        ];
                         $this->row = 0;
                     } else {
                         // non markdownable table
@@ -305,18 +257,18 @@ class ConverterExtra extends Converter
                     $this->handleTagToText();
                 }
             } else {
-                $this->table = array(
-                    'rows' => array(),
-                    'col_widths' => array(),
-                    'aligns' => array(),
-                );
+                $this->table = [
+                    'rows' => [],
+                    'col_widths' => [],
+                    'aligns' => [],
+                ];
                 $this->row = 0;
             }
         } else {
             // finally build the table in Markdown Extra syntax
-            $separator = array();
+            $separator = [];
             if (!isset($this->table['aligns'])) {
-                $this->table['aligns'] = array();
+                $this->table['aligns'] = [];
             }
             // seperator with correct align identifiers
             foreach ($this->table['aligns'] as $col => $align) {
@@ -340,9 +292,9 @@ class ConverterExtra extends Converter
             }
             $separator = '|' . implode('|', $separator) . '|';
 
-            $rows = array();
+            $rows = [];
             // add padding
-            array_walk_recursive($this->table['rows'], array(&$this, 'alignTdContent'));
+            array_walk_recursive($this->table['rows'], [&$this, 'alignTdContent']);
             $header = array_shift($this->table['rows']);
             array_push($rows, '| ' . implode(' | ', $header) . ' |');
             array_push($rows, $separator);
@@ -350,7 +302,7 @@ class ConverterExtra extends Converter
                 array_push($rows, '| ' . implode(' | ', $row) . ' |');
             }
             $this->out(implode("\n" . $this->indent, $rows));
-            $this->table = array();
+            $this->table = [];
             $this->setLineBreaks(2);
         }
     }
@@ -565,7 +517,7 @@ class ConverterExtra extends Converter
         //   <fn name="...">...</fn>
         //   ...
         // </footnotes>
-        $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', array(&$this, '_makeFootnotes'), $html);
+        $html = preg_replace_callback('#<div class="footnotes">\s*<hr />\s*<ol>\s*(.+)\s*</ol>\s*</div>#Us', [&$this, '_makeFootnotes'], $html);
 
         return parent::parseString($html);
     }
@@ -599,6 +551,9 @@ class ConverterExtra extends Converter
 
     /**
      * handle <a> tags parsing
+     *
+     * @param void
+     * @return void
      */
     protected function getCurrentCssSelector()
     {
@@ -611,7 +566,6 @@ class ConverterExtra extends Converter
             $classes = array_filter($classes);
             $cssSelector .= '.' . join('.', $classes);
         }
-
         return $cssSelector;
     }
 }

--- a/includes/markdownify/Parser.php
+++ b/includes/markdownify/Parser.php
@@ -1,7 +1,5 @@
 <?php
 
-/* This file is part of the Markdownify project, which is under LGPL license */
-
 namespace Markdownify;
 
 class Parser
@@ -16,7 +14,7 @@ class Parser
      *
      * @var array<string>
      */
-    public $emptyTags = array(
+    public $emptyTags = [
         'br',
         'hr',
         'input',
@@ -25,7 +23,7 @@ class Parser
         'link',
         'meta',
         'param',
-    );
+    ];
 
     /**
      * tags with preformatted text
@@ -33,12 +31,12 @@ class Parser
      *
      * @var array<string>
      */
-    public $preformattedTags = array(
+    public $preformattedTags = [
         'script',
         'style',
         'pre',
         'code',
-    );
+    ];
 
     /**
      * supress HTML tags inside preformatted tags (see above)
@@ -140,7 +138,7 @@ class Parser
      *
      * @var array
      */
-    public $openTags = array();
+    public $openTags = [];
 
     /**
      * list of block elements
@@ -148,10 +146,11 @@ class Parser
      * @var array
      * TODO: what shall we do with <del> and <ins> ?!
      */
-    public $blockElements = array(
+    public $blockElements = [
         // tag name => <bool> is block
         // block elements
         'address' => true,
+        'aside' => true,
         'blockquote' => true,
         'center' => true,
         'del' => true,
@@ -236,8 +235,9 @@ class Parser
         'sup' => false,
         'textarea' => false,
         'tt' => false,
+        'u' => false,
         'var' => false,
-    );
+    ];
 
     /**
      * get next node, set $this->html prior!
@@ -256,7 +256,7 @@ class Parser
         if ($this->isStartTag && !$this->isEmptyTag) {
             array_push($this->openTags, $this->tagName);
             if (in_array($this->tagName, $this->preformattedTags)) {
-                // dont truncate whitespaces for <code> or <pre> contents
+                // don't truncate whitespaces for <code> or <pre> contents
                 $this->keepWhitespace++;
             }
         }
@@ -354,10 +354,10 @@ class Parser
         if (!isset(static::$a_ord)) {
             static::$a_ord = ord('a');
             static::$z_ord = ord('z');
-            static::$special_ords = array(
+            static::$special_ords = [
                 ord(':'), // for xml:lang
                 ord('-'), // for http-equiv
-            );
+            ];
         }
 
         $tagName = '';
@@ -396,7 +396,7 @@ class Parser
         // get tag attributes
         /** TODO: in html 4 attributes do not need to be quoted **/
         $isEmptyTag = false;
-        $attributes = array();
+        $attributes = [];
         $currAttrib = '';
         while (isset($this->html[$pos + 1])) {
             $pos++;
@@ -413,9 +413,9 @@ class Parser
             if (($pos_ord >= static::$a_ord && $pos_ord <= static::$z_ord) || in_array($pos_ord, static::$special_ords)) {
                 // attribute name
                 $currAttrib .= $this->html[$pos];
-            } elseif (in_array($this->html[$pos], array(' ', "\t", "\n"))) {
+            } elseif (in_array($this->html[$pos], [' ', "\t", "\n"])) {
                 // drop whitespace
-            } elseif (in_array($this->html[$pos] . $this->html[$pos + 1], array('="', "='"))) {
+            } elseif (in_array($this->html[$pos] . $this->html[$pos + 1], ['="', "='"])) {
                 // get attribute value
                 $pos++;
                 $await = $this->html[$pos]; // single or double quote


### PR DESCRIPTION
On PHP 7.3.18,  following warning will be printed, and it'll be also written in a zip file.

`<b>Warning</b>:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in <b>{the directory of wordpress}/wp-content/plugins/wordpress-to-hugo-exporter-1.9.0/includes/markdownify/Converter.php</b> on line <b>351</b><br />`

Then a server will send it with `content-type: text/html` header, and the binary data will be shown as text on a browser.

This problem has been solved on newest markdownify.
So I updated markdownify, and stopped displaying all error and warnings.