### PR TITLE
feat(doc): Adding explanations on where the command is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ above mentioned for a one time conversion of the XML file to the Hugo format.
 3. In the plugin section, go to `Add New`.
 4. Upload the zip of this repo.
 5. Activate the plugin.
-6. In the WP backend run the `Export to Hugo` command.
+6. In the WP backend run the `Export to Hugo` command located under the `Tools` menu.
 7. Collect the ZIP via download.
 8. Copy contents of the zip to your Hugo install and enjoy Hugo.
 


### PR DESCRIPTION
I spent more time than I would like to admit trying to find where the `Export to Hugo` command is located in WP's backend.

Thus I suggest adding those explanations to avoid someone else having the same issue in the future.